### PR TITLE
Fix du docker-compose pour le déploiement en production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,6 +453,7 @@ services:
     environment:
       - ENV=${ENV}
       - NEXT_PUBLIC_API_URL=${ENVIRONMENT_URL}
+      - NEXT_PUBLIC_GRAFANA_URL=${NEXT_PUBLIC_GRAFANA_URL}
       - PORT=3001
     volumes:
       - ./services/frontend:/usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -428,9 +428,10 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@ter_postgres:5432/${POSTGRES_DB}
       - EMAIL_ADDRESS=${EMAIL_ADDRESS}
       - EMAIL_PASSWORD=${EMAIL_PASSWORD}
+      - CORS_ORIGIN=${CORS_ORIGIN}
     volumes:
       - ./services/backend:/usr/src/app
-      
+      - /usr/src/app/node_modules
     depends_on:
       mongodb:
         condition: service_healthy


### PR DESCRIPTION
- Ajout de CORS_ORIGIN dans l'environnement du backend (docker-compose)

- Ajout de NEXT_PUBLIC_GRAFANA_URL dans l'environnement du frontend 

- Ajout du volume anonyme node_modules pour le backend afin d'éviter l'erreur **Cannot find module 'dotenv'** , causée par l'écrasement du dossier node_modules dans le container par le volume monté **./services/backend:/usr/src/app**